### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ While scrolling, VLBScrollView will either use a recycled view or create an exis
 * VLBScrollView
 The 'VLBScrollView.xcodeproj' builds a static library 'libVLBScrollView.a'
 
-# Cocoapods
+# CocoaPods
 
 -> VLBScrollView (1.0)
    A UIScrollView that introduces the concept of 'pages', has built-in recycling and support for both vertical and horizontal orientations.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
